### PR TITLE
Use release.tag_name as tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,4 +24,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: "ghcr.io/${{ github.repository_owner }}/private-demo:${{ github.ref_name }}"
+          tags: "ghcr.io/${{ github.repository_owner }}/private-demo:${{ github.event.release.tag_name }}"


### PR DESCRIPTION
While `ref_name` _should_ still work according to their docs...
It just returns an empty string now `""`