### PR TITLE
Add kitchen sink integration

### DIFF
--- a/rootfs/etc/config/configuration.yaml
+++ b/rootfs/etc/config/configuration.yaml
@@ -11,3 +11,5 @@ command_line:
       name: Build Date
       command: "cat /config/build_date.txt"
       scan_interval: 86400
+      
+kitchen_sink:


### PR DESCRIPTION
Adding this integration allows the docker image to be valid also for the new product-demo deployment.